### PR TITLE
Adding Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "autoload" : {
     "psr-4" : {
-      "PokemonAPI" : "src"
+      "PokemonAPI\\" : "src"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "alex-phillips/PokePHP",
+  "description": "This is a PHP wrapper for the Pokemon API at http://PokeAPI.co/",
+  "licence": "MIT",
+  "authors": [
+    {
+      "name" : "Alex Phillips"
+    }
+  ],
+  "autoload" : {
+    "psr-4" : {
+      "PokemonAPI" : "src"
+    }
+  }
+}

--- a/src/PokemonAPI.php
+++ b/src/PokemonAPI.php
@@ -10,22 +10,6 @@
 
 namespace PokemonAPI;
 
-foreach (
-    array(
-        'Object',
-        'Pokemon',
-        'Ability',
-        'Description',
-        'Egg',
-        'Move',
-        'Type',
-        'Pokedex',
-        'Game',
-        'Sprite',
-    ) as $file) {
-    require_once(__DIR__ . "/$file.php");
-}
-
 /**
  * Class PokemonAPI - this is really only meant to provide a global URL
  *                      as well as provide a single file to include to


### PR DESCRIPTION
Basically, I created the composer.json file and  removed the require_once  method and create the namespace directly in the  composer file. 

so basically we can do:

```
"repositories": [
    {
      "url": "https://github.com/alex-phillips/PokePHP",
      "type": "vcs"
    }
  ],
  "require": {
    "alex-phillips/PokePHP": "dev-master"
  },
```

In any project which uses composer, execute:

```
composer update
```

 and we can start using this package.

```
$mew = new \PokemonAPI\Pokemon('mew');
```
